### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,6 @@ Parameters for processing the raw data are stored in a JSON file in `pipeline_pa
 
 Whether the current trial is a tactile stim trial or an injection trial is determined within `run_pipeline.py` based on the trial name. Tactile stimulation trials are typically 5 minutes long and have `"_5min_"` in the trial name. Injection trials are typically 15 or 30 minutes long.
 
-## Scripts
-
-To display a help message for the scripts:
-
-```bash
-python src/neuroprocessing/scripts/{script.py} --help
-```
-
 ### Image processing pipeline
 
 To process raw imaging data, use `src/neuroprocessing/scripts/run_pipeline.py`. The script includes steps for preprocessing (downsampling and motion correction) and processing (segmentation and bleach correction). For example, to analyze all experiments from a single day, run:


### PR DESCRIPTION
This PR updates the README to prepare for publication. Specific changes:

* Update repo title
* Add links to pub and Zenodo dataset
* Remove references to S3 storage -- instead readers will download raw and processed data from Zenodo
* Simplify bash script that re-processes all raw data
* Add instructions to re-generate figures
* Update paths to analysis files